### PR TITLE
Fix bug in project fork

### DIFF
--- a/server/world/voxels/block.rs
+++ b/server/world/voxels/block.rs
@@ -120,16 +120,8 @@ impl BlockRotation {
                     node[0] += 1.0;
                 }
             }
-            BlockRotation::PY(rot) => {}
-            BlockRotation::NY(rot) => {
-                if y_rotate && (*rot).abs() > f32::EPSILON {
-                    node[0] -= 0.5;
-                    node[2] -= 0.5;
-                    self.rotate_y(node, *rot);
-                    node[0] += 0.5;
-                    node[2] += 0.5;
-                }
-
+            BlockRotation::PY(_) => {}
+            BlockRotation::NY(_) => {
                 self.rotate_x(node, PI_2 * 2.0);
 
                 if translate {


### PR DESCRIPTION
Remove duplicate Y-rotation in `NY_ROTATION` case to align with client implementation and fix incorrect block rotations.

---
<a href="https://cursor.com/background-agent?bcId=bc-47e46497-480e-4c4f-b79a-e4284f0ede42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47e46497-480e-4c4f-b79a-e4284f0ede42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

